### PR TITLE
Block socket access for tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --disable-socket

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 pytest==6.2.2
+pytest-socket==0.4.0
 flake8==3.9.0
 pre-commit==2.11.1


### PR DESCRIPTION
To avoid flaky tests leverage pytest extension to block socket activity